### PR TITLE
fix: img 컴포넌트 분리 및 userList 세부 기능 구현 (#23)

### DIFF
--- a/src/Components/Main/Main.tsx
+++ b/src/Components/Main/Main.tsx
@@ -1,29 +1,51 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import useAxiosWithAuth from "../../Hooks/useAxiosWithAuth";
 import type { UserData } from "../../Interface/interface";
-import { Container, ProfileBox } from "./styled";
+import {
+  CenteredContainer,
+  Container,
+  MessageContainer,
+  ProfileBox,
+} from "./styled";
 import UserProfile from "./UserProfile";
 
 function Main(): JSX.Element {
   const axiosInstance = useAxiosWithAuth();
   const [userList, setUserList] = useState<UserData[]>([]);
 
-  useEffect(() => {
-    async function fetchData() {
-      try {
-        const response = await axiosInstance.get("/member/list");
-        setUserList(response.data);
-      } catch (error) {
-        console.log(error);
-      }
+  async function fetchData() {
+    try {
+      const response = await axiosInstance.get("/member/list");
+      setUserList(response.data);
+    } catch (error) {
+      console.log(error);
     }
+  }
+
+  const onSearch = useCallback(() => {
+    fetchData();
+  }, []);
+
+  useEffect(() => {
     fetchData();
   }, []);
 
   return (
     <Container>
       <ProfileBox>
-        {userList.length > 0 && <UserProfile userList={userList} />}
+        {userList.length > 0 ? (
+          <>
+            <UserProfile userList={userList} onSearch={onSearch} />
+          </>
+        ) : (
+          <CenteredContainer>
+            <MessageContainer>
+              <h6>
+                모든 유저를 둘러봤습니다. <br /> like 탭에 가보세요
+              </h6>
+            </MessageContainer>
+          </CenteredContainer>
+        )}
       </ProfileBox>
     </Container>
   );

--- a/src/Components/Main/UserProfile.tsx
+++ b/src/Components/Main/UserProfile.tsx
@@ -1,30 +1,22 @@
-import { useState } from "react";
 import useAxiosWithAuth from "../../Hooks/useAxiosWithAuth";
 import type { UserListArray } from "../../Interface/interface";
+import UserProfileImg from "../Commons/UserProfileImg";
 import { Button, ButtonContainer, UserName } from "./styled";
-import UserProfileImg from "./UserProfileImg";
+import { ProfileImg } from "../Commons/styled";
 
-export default function UserProfile({ userList }: UserListArray) {
-  const [currentIndex, setCurrentIndex] = useState<number>(0);
+export default function UserProfile({ userList, onSearch }: UserListArray) {
   const axiosInstance = useAxiosWithAuth();
 
   async function handleButtonClick(action: string) {
     try {
-      const targetUser = userList[currentIndex];
+      const targetUser = userList[0];
       const response = await axiosInstance.patch(`/affinity/${action}`, {
         targetUserId: targetUser.userId,
       });
       console.log(
-        `${targetUser.userId} 유저에게 ${action} 버튼 클릭 결과 :${response.data}`
+        `${targetUser.userId} 유저에게 ${action} 버튼 클릭 결과: ${response.data}`
       );
-
-      setCurrentIndex((prevIndex) => {
-        if (prevIndex === userList.length - 1) {
-          return 0;
-        } else {
-          return prevIndex + 1;
-        }
-      });
+      onSearch();
     } catch (error) {
       console.log(error);
     }
@@ -32,9 +24,10 @@ export default function UserProfile({ userList }: UserListArray) {
 
   return (
     <>
-      <UserProfileImg profileImgUrl={userList[currentIndex].profileImgUrl} />
-
-      <UserName>{userList[currentIndex].nickname}</UserName>
+      <ProfileImg className="userProfile">
+        <UserProfileImg profileImgUrl={userList[0].profileImgUrl} />
+      </ProfileImg>
+      <UserName>{userList[0].nickname}</UserName>
       <ButtonContainer>
         <Button id="likeBtn" onClick={() => handleButtonClick("like")}>
           좋아요


### PR DESCRIPTION
### PR 타입
-[fix] : img 컴포넌트 분리 및 userList 세부 기능 구현

### 구현 사항
-  UserProfileImg 컴포넌트 분리 및 Commons으로 이동
- 모든 유저 좋아요 / 싫어요 했을 때 UI 화면 및 기능 구현 
- 자식 컴포넌트 이벤트 이후 부모 컴포넌트 데이터 최신화 기능 구현 (onSearch())