### PR TITLE
fix: img 컴포넌트 분리 및 내부 코드 일부 수정 (#24)

### DIFF
--- a/src/Components/Commons/UserProfileImg.tsx
+++ b/src/Components/Commons/UserProfileImg.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+import { ProfileImg } from "./styled";
+
+interface UserProfileImgProps {
+  profileImgUrl: string;
+}
+
+export default function UserProfileImg({ profileImgUrl }: UserProfileImgProps) {
+  const [imageSrc, setImageSrc] = useState(profileImgUrl);
+  const handleImageError = () => {
+    setImageSrc(`${process.env.PUBLIC_URL}/img/profileicon.png`);
+  };
+
+  useEffect(() => {
+    setImageSrc(profileImgUrl);
+  }, [profileImgUrl]);
+
+  return (
+    <>
+      <ProfileImg>
+        <img src={imageSrc} onError={handleImageError} alt="User Profile" />
+      </ProfileImg>
+    </>
+  );
+}


### PR DESCRIPTION
### PR 타입
-[fix] : img 컴포넌트 분리 및 내부 코드 일부 수정

### 구현 사항
- 공통으로 보여지는 컴포넌트기에 Commons로 분리
- 재활용 가능하게끔 코드 수정